### PR TITLE
Extend compability to scientific notation inputs

### DIFF
--- a/covered_by_POSSUM.py
+++ b/covered_by_POSSUM.py
@@ -84,7 +84,7 @@ def load_and_parse_coordinates(file_path):
 			ra, dec = coord.split(' ')
 			candidate = SkyCoord(ra=ra, dec=dec, unit=(u.hourangle, u.deg), frame='icrs')
 		# Check if the input is in decimal degree format
-		elif re.match(r'^[0-9.+\- ,]+$', coord):
+		elif re.match(r'^[0-9.+\- ,eE]+$', coord):
 			ra, dec = map(float, coord.replace(',',' ').split())
 			candidate = SkyCoord(ra=ra, dec=dec, unit='deg', frame='icrs')
 		else:


### PR DESCRIPTION
The coverage checker doesn't recognize coordinates written out in scientific notation (e.g, ra = 2.0278e+02). Rather than change my coordinates, it was faster to tweak the regex...